### PR TITLE
Update .travis.yml to resolve docker failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
   - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
   - sudo apt-get update
   - sudo apt-get -y install docker-ce
-  - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
+  - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 
 jobs:
   include:


### PR DESCRIPTION
Travis builds are failing because the use of the `-p` flag in the `docker login` command causes a warning that requires user input, making the build time out. This switches the `docker login` command to match [what Travis recommends](https://docs.travis-ci.com/user/docker/#Pushing-a-Docker-Image-to-a-Registry) and should resolve the issue.